### PR TITLE
Implement sticky header. Implement enable drag and swipe bindings.

### DIFF
--- a/ExpandableRecyclerView.Core/ExpandableRecyclerView.Core.csproj
+++ b/ExpandableRecyclerView.Core/ExpandableRecyclerView.Core.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>MvvmCross.ExpandableRecyclerView.Core</AssemblyName>
 		<PackageId>MvxExpandableRecyclerView.Core</PackageId>
 		<RootNamespace>MvvmCross.ExpandableRecyclerView.Core</RootNamespace>
-		<Version>2.0.0</Version>
+		<Version>3.0.0</Version>
 		<Authors>Mohammed Ali Ahmed</Authors>
 		<Company>Mohammed Ali Ahmed</Company>
 		<Product>MvxExpandableRecyclerView</Product>
@@ -17,9 +17,10 @@ This is an unofficial package that contains an expandable AndroidX RecyclerView 
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<RepositoryUrl>https://github.com/Shuh3b/MvxExpandableRecyclerViewSample</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Shuh3b/MvxExpandableRecyclerView</RepositoryUrl>
 		<RepositoryType>GitHub</RepositoryType>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 
 </Project>

--- a/ExpandableRecyclerView.Core/Helpers/TaskItemsHelper.cs
+++ b/ExpandableRecyclerView.Core/Helpers/TaskItemsHelper.cs
@@ -10,18 +10,114 @@ namespace MvvmCross.ExpandableRecyclerView.Core.Helpers
     public static class TaskItemsHelper
     {
         /// <summary>
-        /// Updates the given <see cref="ITaskItem"/> with the given header.
+        /// Cast non-generic <see cref="ITaskItem"/> to a valid <see cref="ITaskItem{TModel, THeader}"/>.
         /// </summary>
-        /// <param name="collection">List of items.</param>
+        /// <typeparam name="TModel">Type to cast model to.</typeparam>
+        /// <typeparam name="THeader">Type to cast header to.</typeparam>
+        /// <param name="item"><see cref="ITaskItem"/> to cast from.</param>
+        /// <returns>An <see cref="ITaskItem{TModel, THeader}"/>.</returns>
+        public static ITaskItem<TModel, THeader> Cast<TModel, THeader>(this ITaskItem item)
+        {
+            return (ITaskItem<TModel, THeader>)item;
+        }
+
+        /// <summary>
+        /// Get strongly typed model matching given type from task item.
+        /// </summary>
+        /// <typeparam name="TModel">Type to cast model to.</typeparam>
+        /// <param name="item"><see cref="ITaskItem"/> to retrieve model from.</param>
+        /// <returns>Strongly typed model from task item.</returns>
+        public static TModel Model<TModel>(this ITaskItem item)
+        {
+            return (TModel)item?.Model;
+        }
+
+        /// <summary>
+        /// Returns the first element's model in a list, or a default value if the list contains no elements.
+        /// </summary>
+        /// <typeparam name="TModel">Type of model to retrieve from list.</typeparam>
+        /// <param name="collection">The <see cref="IList{T}"/> to retrieve the first element from.</param>
+        /// <returns>The first element in the list that passes the test specified by the type. Otherwise returns default(TModel).</returns>
+        public static TModel FirstOrDefaultModel<TModel>(this IList<ITaskItem> collection)
+        {
+            ITaskItem item = collection.FirstOrDefault(i => i.Model is TModel);
+
+            return item?.Model is TModel model ? model : default;
+        }
+
+        /// <summary>
+        /// Returns the first element's model in a list, or a default value if the list contains no elements.
+        /// </summary>
+        /// <typeparam name="TModel">Type of model to retrieve from list.</typeparam>
+        /// <param name="collection">The <see cref="IList{T}"/> to retrieve the first element from.</param>
+        /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <returns>The first element in the list that passes the test specified by the type and predicate. Otherwise returns default(TModel).</returns>
+        public static TModel FirstOrDefaultModel<TModel>(this IList<ITaskItem> collection, Func<TModel, bool> predicate)
+        {
+            ITaskItem item = collection.FirstOrDefault(i => i.Model is TModel m && predicate?.Invoke(m) == true);
+
+            return item?.Model is TModel model ? model : default;
+        }
+
+        /// <summary>
+        /// Returns the last element's model in a list, or a default value if the list contains no elements.
+        /// </summary>
+        /// <typeparam name="TModel">Type of model to retrieve from list.</typeparam>
+        /// <param name="collection">The <see cref="IList{T}"/> to retrieve the last element from.</param>
+        /// <returns>The last element in the list that passes the test specified by the type. Otherwise returns default(TModel).</returns>
+        public static TModel LastOrDefaultModel<TModel>(this IList<ITaskItem> collection)
+        {
+            ITaskItem item = collection.LastOrDefault(i => i.Model is TModel);
+
+            return item?.Model is TModel model ? model : default;
+        }
+
+        /// <summary>
+        /// Returns the last element's model in a list, or a default value if the list contains no elements.
+        /// </summary>
+        /// <typeparam name="TModel">Type of model to retrieve from list.</typeparam>
+        /// <param name="collection">The <see cref="IList{T}"/> to retrieve the last element from.</param>
+        /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <returns>The last element in the list that passes the test specified by the type and predicate. Otherwise returns default(TModel).</returns>
+        public static TModel LastOrDefaultModel<TModel>(this IList<ITaskItem> collection, Func<TModel, bool> predicate)
+        {
+            ITaskItem item = collection.LastOrDefault(i => i.Model is TModel m && predicate?.Invoke(m) == true);
+
+            return item?.Model is TModel model ? model : default;
+        }
+
+        /// <summary>
+        /// Filters a list of task items and returns their models based on the provided type.
+        /// </summary>
+        /// <typeparam name="TModel">Type of model to retrieve from list.</typeparam>
+        /// <param name="collection">The <see cref="IList{T}"/> to filter through.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> that contains elements from the input list that satisfy the type match.</returns>
+        public static IEnumerable<TModel> WhereModel<TModel>(this IList<ITaskItem> collection)
+        {
+            return collection.Where(i => i.Model is TModel).Select(i => (TModel)i.Model);
+        }
+
+        /// <summary>
+        /// Filters a list of task items and returns their models based on the provided type and predicate.
+        /// </summary>
+        /// <typeparam name="TModel">Type of model to retrieve from list.</typeparam>
+        /// <param name="collection">The <see cref="IList{T}"/> to filter through.</param>
+        /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> that contains elements from the input list that satisfy the type match and predicate.</returns>
+        public static IEnumerable<TModel> WhereModel<TModel>(this IList<ITaskItem> collection, Func<TModel, bool> predicate)
+        {
+            return collection.Where(i => i.Model is TModel m && predicate?.Invoke(m) == true).Select(i => (TModel)i.Model);
+        }
+
+        /// <summary>
+        /// Updates an <see cref="ITaskItem"/> with a specified header.
+        /// </summary>
+        /// <param name="collection">The <see cref="IList{T}"/> to retrieve the item from.</param>
         /// <param name="taskItem">The item to update.</param>
         /// <param name="taskHeader">The header to update the item's header to.</param>
-        /// <exception cref="ArgumentNullException">Collection is null.</exception>
         public static void Update(this IList<ITaskItem> collection, ITaskItem taskItem, object taskHeader)
         {
-            if (collection == null)
-                throw new ArgumentNullException(nameof(collection));
-
-            var item = collection.FirstOrDefault(i => i == taskItem);
+            ITaskItem item = collection.FirstOrDefault(i => i == taskItem);
 
             if (collection.Remove(taskItem))
             {
@@ -31,27 +127,17 @@ namespace MvvmCross.ExpandableRecyclerView.Core.Helpers
         }
 
         /// <summary>
-        /// Updates the given list of <see cref="ITaskItem"/> with the given header.
+        /// Updates a list of <see cref="ITaskItem"/> with a specified header.
         /// </summary>
-        /// <param name="collection">List of items.</param>
-        /// <param name="taskItems">List of items to update.</param>
+        /// <param name="collection">The <see cref="IList{T}"/> to retrieve the items from.</param>
+        /// <param name="taskItems">The list of items to update.</param>
         /// <param name="taskHeader">The header to update the item's header to.</param>
-        /// <exception cref="ArgumentNullException">Collection or given enumerable is null.</exception>
         public static void Update(this IList<ITaskItem> collection, IEnumerable<ITaskItem> taskItems, object taskHeader)
         {
-            if (collection == null)
-                throw new ArgumentNullException(nameof(collection));
-
-            if (taskItems == null)
-                throw new ArgumentNullException(nameof(taskItems));
-
-            foreach (var item in taskItems)
+            foreach (ITaskItem item in taskItems.Where(i => collection.Remove(i)))
             {
-                if (collection.Remove(item))
-                {
-                    item.Header = taskHeader;
-                    collection.Add(item);
-                }
+                item.Header = taskHeader;
+                collection.Add(item);
             }
         }
     }

--- a/ExpandableRecyclerView.Core/Models/ITaskItem.cs
+++ b/ExpandableRecyclerView.Core/Models/ITaskItem.cs
@@ -8,19 +8,14 @@ namespace MvvmCross.ExpandableRecyclerView.Core
     public interface ITaskItem : INotifyPropertyChanged
     {
         /// <summary>
-        /// The header to group items by.
-        /// </summary>
-        object Header { get; set; }
-
-        /// <summary>
         /// The underlying data that will be displayed.
         /// </summary>
         object Model { get; }
 
         /// <summary>
-        /// The position of the item within a header.
+        /// The property to group <see cref="Model"/> by.
         /// </summary>
-        int? Sequence { get; set; }
+        object Header { get; set; }
 
         /// <summary>
         /// Used to identify if item has been selected.
@@ -31,5 +26,28 @@ namespace MvvmCross.ExpandableRecyclerView.Core
         /// Used to identify if item has been selected as part of a multi-select process.
         /// </summary>
         bool IsHighlighted { get; set; }
+
+        /// <summary>
+        /// The position of the item within the header.
+        /// </summary>
+        int? Sequence { get; set; }
+    }
+
+    /// <summary>
+    /// Interface exposing properties used for MvxExpandableRecyclerView.
+    /// </summary>
+    /// <typeparam name="TModel">Type of model.</typeparam>
+    /// <typeparam name="THeader">Type of header.</typeparam>
+    public interface ITaskItem<out TModel, THeader> : ITaskItem
+    {
+        /// <summary>
+        /// The underlying data that will be displayed.
+        /// </summary>
+        new TModel Model { get; }
+
+        /// <summary>
+        /// The property to group <see cref="Model"/> by.
+        /// </summary>
+        new THeader Header { get; set; }
     }
 }

--- a/ExpandableRecyclerView.Core/Models/TaskItem.cs
+++ b/ExpandableRecyclerView.Core/Models/TaskItem.cs
@@ -11,7 +11,7 @@ namespace MvvmCross.ExpandableRecyclerView.Core
     /// </summary>
     /// <typeparam name="TModel">Type of model.</typeparam>
     /// <typeparam name="THeader">Type of header.</typeparam>
-    public abstract class TaskItem<TModel, THeader> : ITaskItem
+    public abstract class TaskItem<TModel, THeader> : ITaskItem<TModel, THeader>
     {
         private int? sequence;
         private bool isSelected;
@@ -26,25 +26,23 @@ namespace MvvmCross.ExpandableRecyclerView.Core
             Model = model;
         }
 
-        /// <summary>
-        /// The header to group items by.
-        /// You will need to override <see cref="Header"/> and assign <see cref="Model"/> or a property from it.
-        /// </summary>
-        public abstract THeader Header { get; set; }
-
-        /// <summary>
-        /// The underlying data that will be displayed.
-        /// </summary>
+        /// <inheritdoc/>
         public TModel Model { get; }
 
+        /// <summary>
         /// <inheritdoc/>
-        public int? Sequence { get => sequence; set => SetProperty(ref sequence, value); }
+        /// <para>You will need to override <see cref="Header"/> and assign a property from <see cref="Model"/> or the <see cref="Model"/> itself.</para>
+        /// </summary>
+        public abstract THeader Header { get; set; }
 
         /// <inheritdoc/>
         public bool IsSelected { get => isSelected; set => SetProperty(ref isSelected, value); }
 
         /// <inheritdoc/>
         public bool IsHighlighted { get => isHighlighted; set => SetProperty(ref isHighlighted, value); }
+
+        /// <inheritdoc/>
+        public int? Sequence { get => sequence; set => SetProperty(ref sequence, value); }
 
         /// <inheritdoc/>
         public event PropertyChangedEventHandler PropertyChanged;

--- a/ExpandableRecyclerView.DroidX/Components/IItemTouchHelperCallback.cs
+++ b/ExpandableRecyclerView.DroidX/Components/IItemTouchHelperCallback.cs
@@ -2,7 +2,7 @@
 using MvvmCross.ExpandableRecyclerView.Core;
 using System;
 
-namespace MvvmCross.ExpandableRecyclerView.DroidX
+namespace MvvmCross.ExpandableRecyclerView.DroidX.Components
 {
     /// <summary>
     /// Interface exposing methods used in <see cref="MvxExpandableRecyclerAdapter{THeader}"/> to help with item dragging, swiping, etc.
@@ -10,29 +10,46 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
     public interface IItemTouchHelperCallback
     {
         /// <summary>
-        /// Allows draggable functionality on <see cref="MvxExpandableRecyclerView"/>.
+        /// Whether to enable RecyclerView dragging.
+        /// </summary>
+        bool EnableDrag { get; set; }
+
+        /// <summary>
+        /// Whether to enable RecyclerView swiping.
+        /// </summary>
+        bool EnableSwipe { get; set; }
+
+        /// <summary>
+        /// Allows draggable functionality on <see cref="MvxExpandableRecyclerBaseView"/>.
         /// </summary>
         /// <param name="fromViewHolder">View that's being dragged.</param>
         /// <param name="toViewHolder">View that's being dragged over.</param>
-        void OnMove(RecyclerView.ViewHolder fromViewHolder, RecyclerView.ViewHolder toViewHolder);
+        bool OnMove(RecyclerView.ViewHolder fromViewHolder, RecyclerView.ViewHolder toViewHolder);
 
         /// <summary>
-        /// Executes the corresponding bound property when view is swiped towards start or end direction.
+        /// Executes the corresponding bound property when view is swiped towards right or left direction.
         /// </summary>
         /// <param name="viewHolder">View that was swiped.</param>
-        /// <param name="direction">Whether view was swiped towards start or end direction.</param>
-        /// <exception cref="ArgumentNullException">If any of the swipe-able commands are null.</exception>
+        /// <param name="direction">Whether view was swiped towards the right or left direction.</param>
+        /// <exception cref="ArgumentNullException">If swipe functionality is enabled and any of the swipe-able commands are null.</exception>
         void OnSwiped(RecyclerView.ViewHolder viewHolder, int direction);
 
         /// <summary>
-        /// This executes when <see cref="MvxExpandableRecyclerView"/> has completed an action, i.e. dragging, swiped, etc.
+        /// This executes when an action is executed on a ViewHolder.
         /// </summary>
-        /// <param name="recyclerView"><see cref="MvxExpandableRecyclerView"/>.</param>
-        /// <param name="viewHolder">The view the action was executed on.</param>
+        /// <param name="viewHolder">The ViewHolder the action applies to.</param>
+        /// <param name="actionState">Action taken on the ViewHolder.</param>
+        void OnSelectedChanged(RecyclerView.ViewHolder viewHolder, int actionState);
+
+        /// <summary>
+        /// This executes when <see cref="MvxExpandableRecyclerBaseView"/> has completed an action, i.e. dragging, swiped, etc.
+        /// </summary>
+        /// <param name="recyclerView"><see cref="MvxExpandableRecyclerBaseView"/>.</param>
+        /// <param name="viewHolder">The ViewHolder the action was executed on.</param>
         void OnClearView(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder);
 
         /// <summary>
-        /// Get header.
+        /// Get header associated with task item.
         /// </summary>
         /// <param name="item">Item to get header information from.</param>
         /// <returns>Header matching item's header.</returns>

--- a/ExpandableRecyclerView.DroidX/Components/IStickyHeaderHelper.cs
+++ b/ExpandableRecyclerView.DroidX/Components/IStickyHeaderHelper.cs
@@ -1,0 +1,68 @@
+﻿using MvvmCross.ExpandableRecyclerView.Core;
+using System.Collections.Generic;
+
+namespace MvvmCross.ExpandableRecyclerView.DroidX.Components
+{
+    /// <summary>
+    /// Interface exposing methods used in <see cref="StickyHeaderLayoutManager"/> to display a sticky header on top of <see cref="MvxExpandableRecyclerBaseView"/>.
+    /// </summary>
+    public interface IStickyHeaderHelper
+    {
+        /// <summary>
+        /// The number of items in <see cref="MvxExpandableRecyclerAdapter{THeader}"/>.
+        /// </summary>
+        int ItemCount { get; }
+
+        /// <summary>
+        /// Determines if an item is currently being dragged.
+        /// </summary>
+        bool IsDragging { get; }
+
+        /// <summary>
+        /// Get item view type of item at specified position.
+        /// </summary>
+        /// <param name="position">Position of item.</param>
+        /// <returns>Id of item view type.</returns>
+        int GetItemViewType(int position);
+
+        /// <summary>
+        /// Get all headers in <see cref="MvxExpandableRecyclerAdapter{THeader}"/>.
+        /// </summary>
+        /// <returns>Get a list of headers.</returns>
+        IList<ITaskHeader> GetHeaders();
+
+        /// <summary>
+        /// Get header associated with task item.
+        /// </summary>
+        /// <param name="item">Item to get header information from.</param>
+        /// <returns>Header matching item's header.</returns>
+        ITaskHeader GetHeader(ITaskItem item);
+
+        /// <summary>
+        /// Get header associated with item at position.
+        /// </summary>
+        /// <param name="position">Position of item to use to find header.</param>
+        /// <returns>Header associated with the item.</returns>
+        ITaskHeader GetHeaderAt(int position);
+
+        /// <summary>
+        /// Get position of header associated with item at position.
+        /// </summary>
+        /// <param name="position">Position of item to use to find header position.</param>
+        /// <returns>Position of header.</returns>
+        int GetHeaderPosition(int position);
+
+        /// <summary>
+        /// Check if item at positon is a header.
+        /// </summary>
+        /// <param name="position">Position of item.</param>
+        /// <returns><c>true</c> if item is header. Otherwise <c>false</c>.</returns>
+        bool IsHeader(int position);
+
+        /// <summary>
+        /// Action for clicking on header.
+        /// </summary>
+        /// <param name="header">Header that was clicked.</param>
+        void OnHeaderClick(ITaskHeader header);
+    }
+}

--- a/ExpandableRecyclerView.DroidX/Components/ItemTouchHelperCallback.cs
+++ b/ExpandableRecyclerView.DroidX/Components/ItemTouchHelperCallback.cs
@@ -2,14 +2,14 @@
 using MvvmCross.DroidX.RecyclerView;
 using MvvmCross.ExpandableRecyclerView.Core;
 
-namespace MvvmCross.ExpandableRecyclerView.DroidX
+namespace MvvmCross.ExpandableRecyclerView.DroidX.Components
 {
     /// <summary>
-    /// Helper class for dragging, swiping and updating items in <see cref="MvxExpandableRecyclerView"/>.
+    /// Helper class for dragging, swiping and updating items in <see cref="MvxExpandableRecyclerAdapter{THeader}"/>.
     /// </summary>
     public class ItemTouchHelperCallback : ItemTouchHelper.Callback
     {
-        private readonly IItemTouchHelperCallback adapter;
+        private IItemTouchHelperCallback adapter;
 
         /// <summary>
         /// Constructor.
@@ -20,42 +20,70 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
             this.adapter = adapter;
         }
 
+        /// <summary>
+        /// <see cref="MvxExpandableRecyclerBaseView.Adapter"/>.
+        /// </summary>
+        public IItemTouchHelperCallback Adapter
+        {
+            get => adapter;
+            set
+            {
+                if (adapter != value)
+                {
+                    adapter = value;
+                }
+            }
+        }
+
         /// <inheritdoc/>
         public override int GetMovementFlags(RecyclerView p0, RecyclerView.ViewHolder p1)
         {
             if (!(p1 is IMvxRecyclerViewHolder))
+            {
                 return ItemTouchHelper.ActionStateIdle;
+            }
 
             var holder = (IMvxRecyclerViewHolder)p1;
             if (holder.DataContext is ITaskHeader)
+            {
                 return ItemTouchHelper.ActionStateIdle;
+            }
 
             var item = (ITaskItem)holder.DataContext;
             if (item == null)
+            {
                 return ItemTouchHelper.ActionStateIdle;
+            }
 
             var header = adapter.GetHeader(item);
             if (header == null)
+            {
                 return ItemTouchHelper.ActionStateIdle;
+            }
 
-            int dragFlags = MakeDragFlags(header.Rules);
-            int swipeFlags = MakeSwipeFlags(header.Rules);
+            int dragFlags = adapter.EnableDrag ? MakeDragFlags(header.Rules) : ItemTouchHelper.ActionStateIdle;
+            int swipeFlags = adapter.EnableSwipe ? MakeSwipeFlags(header.Rules) : ItemTouchHelper.ActionStateIdle;
 
             return MakeMovementFlags(dragFlags, swipeFlags);
         }
 
-
         /// <inheritdoc/>
         public override bool OnMove(RecyclerView p0, RecyclerView.ViewHolder p1, RecyclerView.ViewHolder p2)
         {
-            adapter.OnMove(p1, p2);
-            return true;
+            return adapter.OnMove(p1, p2);
         }
 
         /// <inheritdoc/>
         public override void OnSwiped(RecyclerView.ViewHolder p0, int p1)
         {
             adapter.OnSwiped(p0, p1);
+        }
+
+        /// <inheritdoc/>
+        public override void OnSelectedChanged(RecyclerView.ViewHolder viewHolder, int actionState)
+        {
+            base.OnSelectedChanged(viewHolder, actionState);
+            adapter.OnSelectedChanged(viewHolder, actionState);
         }
 
         /// <inheritdoc/>
@@ -68,21 +96,31 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         private int MakeDragFlags(TaskHeaderRule rules)
         {
             if (rules.HasFlag(TaskHeaderRule.DragOutDisabled))
+            {
                 return ItemTouchHelper.ActionStateIdle;
+            }
 
             return ItemTouchHelper.Up | ItemTouchHelper.Down;
         }
 
         private int MakeSwipeFlags(TaskHeaderRule rules)
         {
-            if (rules.HasFlag(TaskHeaderRule.SwipeStartDisabled) && rules.HasFlag(TaskHeaderRule.SwipeEndDisabled))
+            if (rules.HasFlag(TaskHeaderRule.SwipeLeftDisabled) && rules.HasFlag(TaskHeaderRule.SwipeRightDisabled))
+            {
                 return ItemTouchHelper.ActionStateIdle;
-            else if (rules.HasFlag(TaskHeaderRule.SwipeStartDisabled))
+            }
+            else if (rules.HasFlag(TaskHeaderRule.SwipeLeftDisabled))
+            {
                 return ItemTouchHelper.End;
-            else if (rules.HasFlag(TaskHeaderRule.SwipeEndDisabled))
+            }
+            else if (rules.HasFlag(TaskHeaderRule.SwipeRightDisabled))
+            {
                 return ItemTouchHelper.Start;
+            }
             else
+            {
                 return ItemTouchHelper.Start | ItemTouchHelper.End;
+            }
         }
     }
 }

--- a/ExpandableRecyclerView.DroidX/Components/MvxExpandableRecyclerParcel.cs
+++ b/ExpandableRecyclerView.DroidX/Components/MvxExpandableRecyclerParcel.cs
@@ -1,0 +1,50 @@
+﻿using Android.OS;
+using Android.Runtime;
+using Java.Lang;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MvvmCross.ExpandableRecyclerView.DroidX.Components
+{
+    /// <summary>
+    /// <see cref="IParcelable"/> used to save and restore state of <see cref="MvxExpandableRecyclerBaseView"/> when rotating device.
+    /// </summary>
+    internal class MvxExpandableRecyclerParcel : Object, IParcelable
+    {
+        public MvxExpandableRecyclerParcel()
+        { }
+
+        public MvxExpandableRecyclerParcel(Parcel parcel)
+        {
+            SuperState = (IParcelable)parcel.ReadParcelable(Class.ClassLoader);
+            StickyHeaderPosition = parcel.ReadInt();
+            ShowStickyHeader = parcel.ReadBoolean();
+            parcel.ReadList(Headers.ToList(), Class.ClassLoader);
+        }
+
+        public IParcelable SuperState { get; set; }
+
+        public int StickyHeaderPosition { get; set; }
+
+        public bool ShowStickyHeader { get; set; }
+
+        public IList<ITaskHeader> Headers { get; set; }
+
+        public int DescribeContents() => 0;
+
+        public void WriteToParcel(Parcel dest, [GeneratedEnum] ParcelableWriteFlags flags)
+        {
+            try
+            {
+                dest.WriteParcelable(SuperState, flags);
+                dest.WriteInt(StickyHeaderPosition);
+                dest.WriteBoolean(ShowStickyHeader);
+                dest.WriteList(Headers.ToList());
+            }
+            catch
+            {
+                // TODO: A null exception occurs when phone screen turns off. Fix bug and remove try-catch.
+            }
+        }
+    }
+}

--- a/ExpandableRecyclerView.DroidX/Components/StickyHeaderLayoutManager.cs
+++ b/ExpandableRecyclerView.DroidX/Components/StickyHeaderLayoutManager.cs
@@ -1,0 +1,272 @@
+﻿using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using AndroidX.RecyclerView.Widget;
+using Java.Lang;
+using System;
+using System.Collections.Generic;
+
+namespace MvvmCross.ExpandableRecyclerView.DroidX.Components
+{
+    /// <summary>
+    /// Linear Layout Manager for handling sticky header behaviour for <see cref="MvxExpandableRecyclerBaseView"/>.
+    /// </summary>
+    public class StickyHeaderLayoutManager : LinearLayoutManager
+    {
+        private readonly StickyHeaderView stickyHeaderView;
+        private IStickyHeaderHelper adapter;
+        private int stickyHeaderPosition;
+        private bool showStickyHeader = true;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        /// <param name="adapter">Adapter.</param>
+        public StickyHeaderLayoutManager(Context context, IStickyHeaderHelper adapter)
+            : base(context, OrientationHelper.Vertical, false)
+        {
+            this.adapter = adapter;
+            stickyHeaderView = new StickyHeaderView(context, null);
+        }
+
+        /// <inheritdoc/>
+        protected StickyHeaderLayoutManager(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        { }
+
+        /// <summary>
+        /// <see cref="MvxExpandableRecyclerBaseView.Adapter"/>.
+        /// </summary>
+        public IStickyHeaderHelper Adapter
+        {
+            get => adapter;
+            set
+            {
+                if (adapter != value)
+                {
+                    adapter = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Whether to show or hide sticky header.
+        /// </summary>
+        public bool ShowStickyHeader
+        {
+            get => showStickyHeader;
+            set
+            {
+                if (showStickyHeader != value && stickyHeaderView != null)
+                {
+                    showStickyHeader = value;
+                    stickyHeaderView.Visibility = showStickyHeader ? ViewStates.Visible : ViewStates.Gone;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void OnAttachedToWindow(RecyclerView view)
+        {
+            ValidateParentView(view);
+            ViewGroup parent = (ViewGroup)view.Parent;
+            parent.AddView(stickyHeaderView, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent));
+            if (adapter.ItemCount > 0)
+            {
+                int headerPosition = adapter.GetHeaderPosition(stickyHeaderPosition);
+                int headerViewType = adapter.GetItemViewType(headerPosition);
+                var dataContext = adapter.GetHeaderAt(headerPosition);
+                stickyHeaderView.DataContext = dataContext;
+                dataContext.IsSticky = true;
+                stickyHeaderView.TemplateId = headerViewType;
+            }
+
+            stickyHeaderView.Click -= OnHeaderViewClick;
+            stickyHeaderView.Click += OnHeaderViewClick;
+
+            base.OnAttachedToWindow(view);
+        }
+
+        /// <inheritdoc/>
+        public override void OnDetachedFromWindow(RecyclerView view, RecyclerView.Recycler recycler)
+        {
+            if (stickyHeaderView != null)
+            {
+                stickyHeaderView.DataContext.IsSticky = false;
+                stickyHeaderView.DataContext = null;
+                stickyHeaderView.Click -= OnHeaderViewClick;
+            }
+
+            base.OnDetachedFromWindow(view, recycler);
+        }
+
+        /// <inheritdoc/>
+        public override bool SupportsPredictiveItemAnimations() => false;
+
+        /// <inheritdoc/>
+        public override void OnLayoutChildren(RecyclerView.Recycler recycler, RecyclerView.State state)
+        {
+            base.OnLayoutChildren(recycler, state);
+            if (showStickyHeader && !adapter.IsDragging)
+            {
+                TranslateStickyHeader(); // Fixes edge-case where one header can overlap another, causing a visual glitch.
+                UpdateStickyHeader();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override int ScrollVerticallyBy(int dy, RecyclerView.Recycler recycler, RecyclerView.State state)
+        {
+            int scroll = base.ScrollVerticallyBy(dy, recycler, state);
+            if (showStickyHeader)
+            {
+                TranslateStickyHeader();
+                UpdateStickyHeaderState();
+            }
+
+            return scroll;
+        }
+
+        /// <inheritdoc/>
+        public override IParcelable OnSaveInstanceState()
+        {
+            MvxExpandableRecyclerParcel parcel = new MvxExpandableRecyclerParcel
+            {
+                SuperState = base.OnSaveInstanceState(),
+                StickyHeaderPosition = stickyHeaderPosition,
+                ShowStickyHeader = showStickyHeader,
+                Headers = adapter.ItemCount > 0 ? adapter.GetHeaders() : new List<ITaskHeader>(),
+            };
+
+            return parcel;
+        }
+
+        /// <inheritdoc/>
+        public override void OnRestoreInstanceState(IParcelable state)
+        {
+            var parcel = state as MvxExpandableRecyclerParcel;
+            stickyHeaderPosition = parcel.StickyHeaderPosition;
+            ShowStickyHeader = parcel.ShowStickyHeader;
+            if (adapter?.ItemCount > 0)
+            {
+                foreach (var header in parcel.Headers)
+                {
+                    var realHeader = adapter.GetHeader(header);
+                    if (realHeader != null && realHeader.IsCollapsed != header.IsCollapsed)
+                    {
+                        adapter.OnHeaderClick(realHeader);
+                    }
+                }
+            }
+
+            base.OnRestoreInstanceState(parcel.SuperState);
+        }
+
+        private void ValidateParentView(RecyclerView view)
+        {
+            var parent = view.Parent;
+            if (!(parent is FrameLayout) && !(parent is AndroidX.CoordinatorLayout.Widget.CoordinatorLayout))
+            {
+                throw new IllegalArgumentException("RecyclerView Parent must be either a FrameLayout or CoordinatorLayout");
+            }
+        }
+
+        private void OnHeaderViewClick(object sender, EventArgs e)
+        {
+            if (adapter.ItemCount <= 0)
+            {
+                return;
+            }
+
+            int position = FindFirstVisibleItemPosition();
+            if (position == RecyclerView.NoPosition)
+            {
+                return;
+            }
+
+            int headerPosition = adapter.GetHeaderPosition(position);
+            var header = adapter.GetHeaderAt(headerPosition);
+            adapter.OnHeaderClick(header);
+            ScrollToPosition(headerPosition);
+        }
+
+        private void UpdateStickyHeaderState()
+        {
+            if (adapter.IsDragging)
+            {
+                if (stickyHeaderView.Visibility != ViewStates.Gone)
+                {
+                    stickyHeaderView.Visibility = ViewStates.Gone;
+                }
+            }
+            else
+            {
+                UpdateStickyHeader();
+            }
+        }
+
+        private void UpdateStickyHeader()
+        {
+            if (adapter.ItemCount <= 0)
+            {
+                return;
+            }
+
+            if (stickyHeaderView.Visibility != ViewStates.Visible)
+            {
+                stickyHeaderView.Visibility = ViewStates.Visible;
+            }
+
+            int headerPosition = adapter.GetHeaderPosition(FindFirstVisibleItemPosition());
+            if (headerPosition == RecyclerView.NoPosition || headerPosition == stickyHeaderPosition)
+            {
+                return;
+            }
+
+            stickyHeaderPosition = headerPosition;
+            stickyHeaderView.DataContext.IsSticky = false;
+            stickyHeaderView.DataContext = adapter.GetHeaderAt(headerPosition);
+            stickyHeaderView.DataContext.IsSticky = true;
+
+            int headerViewType = adapter.GetItemViewType(headerPosition);
+            if (stickyHeaderView.TemplateId != headerViewType)
+            {
+                stickyHeaderView.TemplateId = headerViewType;
+            }
+        }
+
+        private void TranslateStickyHeader()
+        {
+            if (adapter.ItemCount <= 0)
+            {
+                return;
+            }
+
+            int contactPoint = stickyHeaderView.Bottom;
+            View childInContact = null;
+
+            for (int i = 0; i < ChildCount; i++)
+            {
+                var child = GetChildAt(i);
+                if (child.Bottom > contactPoint && child.Top <= contactPoint)
+                {
+                    childInContact = child;
+                    break;
+                }
+            }
+
+            int position = GetPosition(childInContact);
+            if (position != RecyclerView.NoPosition && position <= ItemCount && adapter.IsHeader(position))
+            {
+                stickyHeaderView.TranslationY = childInContact.Top - stickyHeaderView.Height;
+            }
+            else
+            {
+                stickyHeaderView.TranslationY = 0;
+            }
+        }
+    }
+}

--- a/ExpandableRecyclerView.DroidX/Components/StickyHeaderView.cs
+++ b/ExpandableRecyclerView.DroidX/Components/StickyHeaderView.cs
@@ -1,0 +1,179 @@
+﻿using Android.Content;
+using Android.Runtime;
+using Android.Util;
+using Android.Views;
+using Android.Widget;
+using Microsoft.Extensions.Logging;
+using MvvmCross.Binding.Attributes;
+using MvvmCross.Binding.BindingContext;
+using MvvmCross.Exceptions;
+using MvvmCross.Platforms.Android.Binding.BindingContext;
+using MvvmCross.Platforms.Android.Binding.Views;
+using System;
+
+namespace MvvmCross.ExpandableRecyclerView.DroidX.Components
+{
+    /// <summary>
+    /// View for displaying and "sticking" top most available header to the top of the screen.
+    /// </summary>
+    public class StickyHeaderView : FrameLayout, IMvxBindingContextOwner
+    {
+        private readonly IMvxAndroidBindingContext bindingContext;
+        private int templateId;
+        private ITaskHeader cachedDataContext;
+        private bool isAttachedToWindow;
+        private View content;
+
+        /// <summary>
+        /// Create an instance of StickyHeaderView.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        /// <param name="attrs">Attrs.</param>
+        public StickyHeaderView(Context context, IAttributeSet attrs)
+            : this(MvxAttributeHelpers.ReadTemplateId(context, attrs), context, attrs)
+        { }
+
+        /// <summary>
+        /// Create an instance of StickyHeaderView.
+        /// </summary>
+        /// <param name="templateId">View Type Id.</param>
+        /// <param name="context">Context.</param>
+        /// <param name="attrs">Attrs.</param>
+        public StickyHeaderView(int templateId, Context context, IAttributeSet attrs)
+            : base(context, attrs)
+        {
+            this.templateId = templateId;
+
+            if (!(context is IMvxLayoutInflaterHolder))
+            {
+                throw new MvxException("The owning Context for a MvxFrameControl must implement LayoutInflater");
+            }
+
+            bindingContext = new MvxAndroidBindingContext(context, (IMvxLayoutInflaterHolder)context);
+            this.DelayBind(() =>
+            {
+                if (Content == null && this.templateId != 0)
+                {
+                    MvxLogHost.GetLog<MvxFrameControl>()?.Log(LogLevel.Trace, "DataContext is {dataContext}", DataContext?.ToString() ?? "Null");
+                    Content = bindingContext.BindingInflate(this.templateId, this);
+                }
+            });
+        }
+
+        /// <inheritdoc/>
+        protected StickyHeaderView(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        { }
+
+        /// <summary>
+        /// Android Binding Context.
+        /// </summary>
+        protected IMvxAndroidBindingContext AndroidBindingContext => bindingContext;
+
+        /// <summary>
+        /// Binding Context.
+        /// </summary>
+        public IMvxBindingContext BindingContext
+        {
+            get => bindingContext;
+            set => throw new NotImplementedException("BindingContext is readonly in the list item");
+        }
+
+        /// <summary>
+        /// View Type Id.
+        /// </summary>
+        public int TemplateId
+        {
+            get => templateId;
+            set
+            {
+                templateId = value;
+                if (templateId != 0)
+                {
+                    MvxLogHost.GetLog<MvxFrameControl>()?.Log(LogLevel.Trace, "DataContext is {dataContext}", DataContext?.ToString() ?? "Null");
+                    this.ClearAllBindings();
+                    RemoveAllViews();
+                    Content = bindingContext.BindingInflate(templateId, this);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.ClearAllBindings();
+                if (cachedDataContext != null)
+                {
+                    cachedDataContext = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnAttachedToWindow()
+        {
+            base.OnAttachedToWindow();
+            isAttachedToWindow = true;
+            if (cachedDataContext != null && DataContext == null)
+            {
+                DataContext = cachedDataContext;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnDetachedFromWindow()
+        {
+            cachedDataContext = DataContext;
+            DataContext = null;
+            base.OnDetachedFromWindow();
+            isAttachedToWindow = false;
+        }
+
+        /// <summary>
+        /// Inflated view created using the given DataContext and TemplateId.
+        /// </summary>
+        protected View Content
+        {
+            get => content;
+            set
+            {
+                content = value;
+                OnContentSet();
+            }
+        }
+
+        /// <summary>
+        /// Set Content.
+        /// </summary>
+        protected virtual void OnContentSet()
+        { }
+
+        /// <summary>
+        /// Header attached to this view.
+        /// </summary>
+        [MvxSetToNullAfterBinding]
+        public ITaskHeader DataContext
+        {
+            get => bindingContext.DataContext as ITaskHeader;
+            set
+            {
+                if (isAttachedToWindow)
+                {
+                    bindingContext.DataContext = value;
+                }
+                else
+                {
+                    cachedDataContext = value;
+                    if (bindingContext.DataContext != null)
+                    {
+                        bindingContext.DataContext = null;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ExpandableRecyclerView.DroidX/Enums/TaskHeaderRule.cs
+++ b/ExpandableRecyclerView.DroidX/Enums/TaskHeaderRule.cs
@@ -3,7 +3,7 @@
 namespace MvvmCross.ExpandableRecyclerView.DroidX
 {
     /// <summary>
-    /// Custom rules for task headers.
+    /// Custom rules for headers.
     /// </summary>
     [Flags]
     public enum TaskHeaderRule
@@ -24,14 +24,14 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         DragOutDisabled = 2,
 
         /// <summary>
-        /// Prevent items being swiped towards start direction.
+        /// Prevent items being swiped towards the right.
         /// </summary>
-        SwipeStartDisabled = 4,
+        SwipeRightDisabled = 4,
 
         /// <summary>
-        /// Prevent items being swiped towards end direction.
+        /// Prevent items being swiped towards the left.
         /// </summary>
-        SwipeEndDisabled = 8,
+        SwipeLeftDisabled = 8,
 
         /// <summary>
         /// Items under header will not be sequenced.

--- a/ExpandableRecyclerView.DroidX/ExpandableRecyclerView.DroidX.csproj
+++ b/ExpandableRecyclerView.DroidX/ExpandableRecyclerView.DroidX.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>MvvmCross.ExpandableRecyclerView.DroidX</AssemblyName>
 		<PackageId>MvxExpandableRecyclerView.DroidX</PackageId>
 		<RootNamespace>MvvmCross.ExpandableRecyclerView.DroidX</RootNamespace>
-		<Version>2.0.0</Version>
+		<Version>3.0.0</Version>
 		<Authors>Mohammed Ali Ahmed</Authors>
 		<Company>Mohammed Ali Ahmed</Company>
 		<Product>MvxExpandableRecyclerView</Product>
@@ -17,9 +17,10 @@ This is an unofficial package that contains an expandable AndroidX RecyclerView 
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<RepositoryUrl>https://github.com/Shuh3b/MvxExpandableRecyclerViewSample</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Shuh3b/MvxExpandableRecyclerView</RepositoryUrl>
 		<RepositoryType>GitHub</RepositoryType>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/ExpandableRecyclerView.DroidX/IMvxExpandableRecyclerAdapter.cs
+++ b/ExpandableRecyclerView.DroidX/IMvxExpandableRecyclerAdapter.cs
@@ -1,21 +1,28 @@
 ﻿using MvvmCross.DroidX.RecyclerView;
+using MvvmCross.ExpandableRecyclerView.Core;
+using MvvmCross.ExpandableRecyclerView.DroidX.Components;
 using System.Windows.Input;
 
 namespace MvvmCross.ExpandableRecyclerView.DroidX
 {
     /// <summary>
-    /// Interface exposing adapter properties used for <see cref="MvxExpandableRecyclerView"/>.
+    /// Interface exposing adapter properties used for <see cref="MvxExpandableRecyclerAdapter{THeader}"/>.
     /// </summary>
-    public interface IMvxExpandableRecyclerAdapter : IMvxRecyclerAdapter, IMvxRecyclerAdapterBindableHolder, IItemTouchHelperCallback
+    public interface IMvxExpandableRecyclerAdapter : IMvxRecyclerAdapter, IMvxRecyclerAdapterBindableHolder, IItemTouchHelperCallback, IStickyHeaderHelper
     {
         /// <summary>
-        /// Get or set the <see cref="ICommand"/> to trigger when an item was swiped towards the start direction.
+        /// Get or set the <see cref="ICommand"/> to trigger when an item was swiped towards the right.
         /// </summary>
-        ICommand ItemSwipeStart { get; set; }
+        ICommand ItemSwipeRight { get; set; }
 
         /// <summary>
-        /// Get or set the <see cref="ICommand"/> to trigger when an item was swiped towards the end direction.
+        /// Get or set the <see cref="ICommand"/> to trigger when an item was swiped towards the left.
         /// </summary>
-        ICommand ItemSwipeEnd { get; set; }
+        ICommand ItemSwipeLeft { get; set; }
+
+        /// <summary>
+        /// Item that was last interacted with.
+        /// </summary>
+        ITaskItem SelectedItem { get; }
     }
 }

--- a/ExpandableRecyclerView.DroidX/Models/ITaskHeader.cs
+++ b/ExpandableRecyclerView.DroidX/Models/ITaskHeader.cs
@@ -29,6 +29,11 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         int Count { get; }
 
         /// <summary>
+        /// Whether header is a sticky header or not.
+        /// </summary>
+        bool IsSticky { get; set; }
+
+        /// <summary>
         /// Custom rules for header.
         /// </summary>
         TaskHeaderRule Rules { get; set; }

--- a/ExpandableRecyclerView.DroidX/Models/SimpleTaskHeader.cs
+++ b/ExpandableRecyclerView.DroidX/Models/SimpleTaskHeader.cs
@@ -3,9 +3,9 @@
 namespace MvvmCross.ExpandableRecyclerView.DroidX
 {
     /// <summary>
-    /// Class used to show simple headers in <see cref="MvxExpandableRecyclerView"/>.
+    /// Class used to show simple headers in <see cref="MvxExpandableRecyclerBaseView"/>.
     /// </summary>
-    /// <typeparam name="TModel">Type of model for header.</typeparam>
+    /// <typeparam name="TModel">Type of model used for header.</typeparam>
     public class SimpleTaskHeader<TModel> : TaskHeader<TModel, TModel>
     {
         /// <summary>

--- a/ExpandableRecyclerView.DroidX/MvxAndroidLog.cs
+++ b/ExpandableRecyclerView.DroidX/MvxAndroidLog.cs
@@ -16,7 +16,9 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         public static ILogger<T> GetLog<T>()
         {
             if (Mvx.IoCProvider.TryResolve<ILoggerFactory>(out var loggerFactory))
+            {
                 return loggerFactory.CreateLogger<T>();
+            }
 
             return null;
         }
@@ -24,7 +26,9 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         public static ILogger GetLog(string categoryName)
         {
             if (Mvx.IoCProvider.TryResolve<ILoggerFactory>(out var loggerFactory))
+            {
                 return loggerFactory.CreateLogger(categoryName);
+            }
 
             return null;
         }

--- a/ExpandableRecyclerView.DroidX/MvxExpandableRecyclerAdapter.cs
+++ b/ExpandableRecyclerView.DroidX/MvxExpandableRecyclerAdapter.cs
@@ -20,11 +20,11 @@ using System.Windows.Input;
 namespace MvvmCross.ExpandableRecyclerView.DroidX
 {
     /// <summary>
-    /// An adapter that works with <see cref="MvxExpandableRecyclerView"/>, to create a bindable, expandable, draggable and/or swipe-able RecyclerView.
-    /// <para>Custom headers can be added/edited/removed by inheriting this object, overriding <see cref="GenerateHeader(object)"/> and attaching the derived adapter to <see cref="MvxExpandableRecyclerView"/>.</para>
+    /// An adapter that works with <see cref="MvxExpandableRecyclerBaseView"/>, to create a bindable, expandable, draggable and/or swipe-able RecyclerView.
+    /// <para>Custom headers can be added/edited/grouped by inheriting this class, overriding <see cref="GenerateHeader(THeader)"/> and attaching the derived class to <see cref="MvxExpandableRecyclerView"/> or <see cref="MvxExpandableRecyclerBaseView"/>.</para>
     /// <code>
-    /// var expandableRecyclerView = _view.FindViewById<MvxExpandableRecyclerView>(Resource.Id.expandablerecyclerview);
-    /// recyclerView.Adapter = new CustomExpandableRecyclerAdapter((IMvxAndroidBindingContext)BindingContext);
+    /// MvxExpandableRecyclerView expandableRecyclerView = _view.FindViewById&lt;MvxExpandableRecyclerView&gt;(Resource.Id.expandablerecyclerview);
+    /// expandableRecyclerView.Adapter = new CustomExpandableRecyclerAdapter((IMvxAndroidBindingContext)BindingContext);
     /// </code>
     /// </summary>
     /// <typeparam name="THeader">Header type to use.</typeparam>
@@ -33,50 +33,71 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         private IList<ITaskItem> viewItemsSource, itemsSource;
         private IDisposable subscription;
         private IMvxTemplateSelector itemTemplateSelector;
-        private ICommand itemSwipeStart, itemSwipeEnd;
+        private ICommand itemSwipeRight, itemSwipeLeft;
+        private ITaskItem selectedItem;
+        private bool isDragging;
 
         /// <summary>
-        /// Constructor.
+        /// Create an instance of MvxExpandableRecyclerAdapter.
         /// </summary>
         public MvxExpandableRecyclerAdapter()
-            : this(null) { }
+            : this(null)
+        { }
 
         /// <summary>
-        /// Constructor.
+        /// Create an instance of MvxExpandableRecyclerAdapter.
         /// </summary>
         /// <param name="bindingContext">Binding context.</param>
         public MvxExpandableRecyclerAdapter(IMvxAndroidBindingContext bindingContext)
-            : base(bindingContext) { }
+            : base(bindingContext)
+        { }
 
         /// <summary>
-        /// Get or set the <see cref="ICommand"/> to trigger when an item was swiped towards the start direction.
+        /// Item that was last interacted with.
         /// </summary>
+        public ITaskItem SelectedItem => selectedItem;
+
+        /// <inheritdoc/>
+        public bool IsDragging => isDragging;
+
+        /// <inheritdoc/>
+        public bool IsInteractive { get; set; }
+
+        /// <inheritdoc/>
+        public bool EnableDrag { get; set; }
+
+        /// <inheritdoc/>
+        public bool EnableSwipe { get; set; }
+
+        /// <inheritdoc/>
         [MvxSetToNullAfterBinding]
-        public ICommand ItemSwipeStart
+        public ICommand ItemSwipeRight
         {
-            get => itemSwipeStart;
+            get => itemSwipeRight;
             set
             {
-                if (ReferenceEquals(itemSwipeStart, value))
+                if (ReferenceEquals(itemSwipeRight, value))
+                {
                     return;
+                }
 
-                itemSwipeStart = value;
+                itemSwipeRight = value;
             }
         }
 
-        /// <summary>
-        /// Get or set the <see cref="ICommand"/> to trigger when an item was swiped towards the end direction.
-        /// </summary>
+        /// <inheritdoc/>
         [MvxSetToNullAfterBinding]
-        public ICommand ItemSwipeEnd
+        public ICommand ItemSwipeLeft
         {
-            get => itemSwipeEnd;
+            get => itemSwipeLeft;
             set
             {
-                if (ReferenceEquals(itemSwipeEnd, value))
+                if (ReferenceEquals(itemSwipeLeft, value))
+                {
                     return;
+                }
 
-                itemSwipeEnd = value;
+                itemSwipeLeft = value;
             }
         }
 
@@ -96,12 +117,16 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
             set
             {
                 if (ReferenceEquals(itemTemplateSelector, value))
+                {
                     return;
+                }
 
                 itemTemplateSelector = value;
 
                 if (viewItemsSource != null && itemsSource != null)
+                {
                     NotifyDataSetChanged();
+                }
             }
         }
 
@@ -114,15 +139,14 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
             var dataContext = GetItem(position);
             if (holder is IMvxRecyclerViewHolder viewHolder)
             {
+                viewHolder.DataContext = dataContext;
                 if (dataContext is ITaskHeader)
                 {
-                    viewHolder.DataContext = dataContext;
                     viewHolder.Click -= OnHeaderViewClick;
                     viewHolder.Click += OnHeaderViewClick;
                 }
                 else
                 {
-                    viewHolder.DataContext = dataContext;
                     viewHolder.Click -= base.OnItemViewClick;
                     viewHolder.LongClick -= base.OnItemViewLongClick;
                     viewHolder.Click += base.OnItemViewClick;
@@ -134,6 +158,7 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
                     ((TextView)holder.ItemView).Text = dataContext?.ToString();
                 }
             }
+
             OnMvxViewHolderBound(new MvxViewHolderBoundEventArgs(position, dataContext, holder));
         }
 
@@ -151,6 +176,7 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
                     viewHolder.Click -= OnItemViewClick;
                     viewHolder.LongClick -= OnItemViewLongClick;
                 }
+
                 viewHolder.OnViewRecycled();
             }
         }
@@ -158,12 +184,15 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         /// <inheritdoc/>
         public override object GetItem(int viewPosition)
         {
-            var itemsSourcePosition = GetItemsSourcePosition(viewPosition);
+            int itemsSourcePosition = GetItemsSourcePosition(viewPosition);
 
             if (viewItemsSource is IList items)
             {
                 if (itemsSourcePosition >= 0 && itemsSourcePosition < items.Count)
+                {
                     return items[itemsSourcePosition];
+                }
+
                 MvxAndroidLog.Instance.Log(LogLevel.Error,
                     "MvxExpandableRecyclerView GetItem index out of range. viewPosition: {ViewPosition}, itemsSourcePosition: {ItemsSourcePosition}, itemCount: {ItemsSourceCount}",
                     viewPosition, itemsSourcePosition, viewItemsSource.Count());
@@ -176,7 +205,7 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         /// <inheritdoc/>
         protected override int GetViewPosition(object item)
         {
-            var itemsSourcePosition = viewItemsSource.GetPosition(item);
+            int itemsSourcePosition = viewItemsSource.GetPosition(item);
             return GetViewPosition(itemsSourcePosition);
         }
 
@@ -184,23 +213,29 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         protected override void SetItemsSource(IEnumerable value)
         {
             if (Looper.MainLooper != Looper.MyLooper())
-                MvxAndroidLog.Instance.Log(LogLevel.Error,
-                    "ItemsSource property set on a worker thread. This leads to crash in the RecyclerView. It must be set only from the main thread.");
+            {
+                MvxAndroidLog.Instance.Log(LogLevel.Error, "ItemsSource property set on a worker thread. This leads to crash in the RecyclerView. It must be set only from the main thread.");
+            }
 
             if (ReferenceEquals(itemsSource, value) && !ReloadOnAllItemsSourceSets)
+            {
                 return;
+            }
 
             subscription?.Dispose();
             subscription = null;
 
             if (value != null && !(value is IList<ITaskItem>))
-                MvxAndroidLog.Instance.Log(LogLevel.Error,
-                    "ItemsSource property should inherit IList<ITaskItem>. If not, this will lead to items not displaying in the RecyclerView.");
+            {
+                MvxAndroidLog.Instance.Log(LogLevel.Error, "ItemsSource property should inherit IList<ITaskItem>. If not, this will lead to items not displaying in the RecyclerView.");
+            }
 
-            var val = value as IList<ITaskItem>;
+            IList<ITaskItem> val = value as IList<ITaskItem>;
 
             if (val is INotifyCollectionChanged newObservable)
+            {
                 subscription = newObservable.WeakSubscribe(OnItemsSourceCollectionChanged);
+            }
 
             if (val == null)
             {
@@ -221,16 +256,22 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         protected override void OnItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             if (subscription == null || itemsSource == null)
+            {
                 return;
+            }
 
             if (Looper.MainLooper == Looper.MyLooper())
+            {
                 NotifyDataSetChanged(e);
+            }
             else
+            {
                 MvxAndroidLog.Instance.Log(LogLevel.Error,
                     $@"ItemsSource collection content changed on a worker thread.
 This leads to crash in the RecyclerView as it will not be aware of changes
 immediatly and may get a deleted item or update an item with a bad item template.
 All changes must be synchronized on the main thread.");
+            }
         }
 
         /// <inheritdoc/>
@@ -265,28 +306,32 @@ All changes must be synchronized on the main thread.");
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
             subscription?.Dispose();
             subscription = null;
-            itemSwipeStart = null;
-            itemSwipeEnd = null;
+            itemSwipeLeft = null;
+            itemSwipeRight = null;
             itemTemplateSelector = null;
+            base.Dispose(disposing);
         }
 
         /// <inheritdoc/>
-        public virtual void OnMove(RecyclerView.ViewHolder fromViewHolder, RecyclerView.ViewHolder toViewHolder)
+        public virtual bool OnMove(RecyclerView.ViewHolder fromViewHolder, RecyclerView.ViewHolder toViewHolder)
         {
             int toPosition = toViewHolder.AdapterPosition;
-
-            if (toPosition <= 0)
-                return;
-
             int fromPosition = fromViewHolder.AdapterPosition;
 
-            var item = viewItemsSource[fromPosition];
-            viewItemsSource.RemoveAt(fromPosition);
+            if (toPosition <= 0 || fromPosition == toPosition)
+            {
+                return false;
+            }
+
+            isDragging = true;
+
+            ITaskItem item = viewItemsSource[fromPosition];
+            viewItemsSource.Remove(item);
             viewItemsSource.Insert(toPosition, item);
             NotifyItemMoved(fromPosition, toPosition);
+            return true;
         }
 
         /// <inheritdoc/>
@@ -296,48 +341,64 @@ All changes must be synchronized on the main thread.");
             {
                 if (direction == ItemTouchHelper.Start)
                 {
-                    if (ItemSwipeStart == null)
-                        throw new ArgumentNullException(nameof(ItemSwipeStart),
-                            $"Either implement swipe feature and bind to {nameof(ItemSwipeStart)} or disable swiping towards start direction.");
+                    if (ItemSwipeLeft == null)
+                    {
+                        throw new ArgumentNullException(nameof(ItemSwipeLeft), $"Either implement swipe feature and bind to {nameof(ItemSwipeLeft)} or disable swiping towards start direction.");
+                    }
 
-                    ExecuteCommandOnItem(ItemSwipeStart, holder.DataContext);
+                    ExecuteCommandOnItem(ItemSwipeLeft, holder.DataContext);
                 }
                 else if (direction == ItemTouchHelper.End)
                 {
-                    if (ItemSwipeEnd == null)
-                        throw new ArgumentNullException(nameof(ItemSwipeEnd),
-                            $"Either implement swipe feature and bind to {nameof(ItemSwipeEnd)} or disable swiping towards end direction.");
+                    if (ItemSwipeRight == null)
+                    {
+                        throw new ArgumentNullException(nameof(ItemSwipeRight), $"Either implement swipe feature and bind to {nameof(ItemSwipeRight)} or disable swiping towards end direction.");
+                    }
 
-                    ExecuteCommandOnItem(ItemSwipeEnd, holder.DataContext);
+                    ExecuteCommandOnItem(ItemSwipeRight, holder.DataContext);
                 }
             }
         }
 
         /// <inheritdoc/>
+        public virtual void OnSelectedChanged(RecyclerView.ViewHolder viewHolder, int actionState)
+        {
+            // TODO: Implement.
+        }
+
+        /// <inheritdoc/>
         public virtual void OnClearView(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder)
         {
+            isDragging = false;
+
             int itemPosition = viewHolder.AdapterPosition;
 
             if (itemPosition <= 0)
-                return;
-
-            var item = viewItemsSource[itemPosition];
-            var aboveItem = viewItemsSource[itemPosition - 1];
-
-            var previousHeader = GetHeader(item);
-            var newHeader = GetHeader(aboveItem);
-
-            if (previousHeader.Header.Equals(newHeader.Header))
             {
-                int position = itemPosition - viewItemsSource.GetPosition(previousHeader) - 1;
-                item.Sequence = position;
-                previousHeader.Items.Remove(item);
-                previousHeader.Items.Insert(position, item);
+                selectedItem = null;
                 return;
             }
 
-            if (TaskHeaderDragInDisabled(newHeader, item))
+            ITaskItem item = viewItemsSource[itemPosition];
+            selectedItem = item;
+            ITaskItem aboveItem = viewItemsSource[itemPosition - 1];
+
+            ITaskHeader previousHeader = GetHeader(item);
+            ITaskHeader newHeader = GetHeader(aboveItem);
+
+            if (previousHeader.Header.Equals(newHeader.Header))
+            {
+                int sequence = itemPosition - viewItemsSource.GetPosition(previousHeader) - 1;
+                item.Sequence = sequence;
+                previousHeader.Items.Remove(item);
+                previousHeader.Items.Insert(sequence, item);
                 return;
+            }
+
+            if (TaskHeaderDragInDisabled(newHeader, item, recyclerView))
+            {
+                return;
+            }
 
             item.Header = newHeader.Header;
             previousHeader.Items.Remove(item);
@@ -347,17 +408,17 @@ All changes must be synchronized on the main thread.");
                 item.Sequence = null;
                 newHeader.Items.Add(item);
                 viewItemsSource.Remove(item);
-                NotifyItemRemoved(itemPosition);
+                Notify(recyclerView, NotifyItemRemoved, itemPosition);
             }
             else
             {
-                int position = itemPosition - viewItemsSource.GetPosition(newHeader) - 1;
-                item.Sequence = position;
-                newHeader.Items.Insert(position, item);
-                NotifyItemChanged(itemPosition);
+                int sequence = itemPosition - viewItemsSource.GetPosition(newHeader) - 1;
+                item.Sequence = sequence;
+                newHeader.Items.Insert(sequence, item);
+                Notify(recyclerView, NotifyItemChanged, itemPosition);
             }
 
-            RemoveTemporaryTaskHeader(previousHeader);
+            RemoveTemporaryTaskHeader(previousHeader, recyclerView);
         }
 
         /// <summary>
@@ -380,13 +441,34 @@ All changes must be synchronized on the main thread.");
         }
 
         /// <summary>
-        /// Get items in header.
+        /// Get header associated with item at position.
         /// </summary>
-        /// <param name="header">Header.</param>
-        /// <returns>List of items with matching header.</returns>
-        public IList<ITaskItem> GetItemsInHeader(ITaskHeader header)
+        /// <param name="position">Position of item to use to find header.</param>
+        /// <returns>Header associated with the item.</returns>
+        public ITaskHeader GetHeaderAt(int position)
         {
-            return header.Items;
+            return GetHeader(viewItemsSource[position]);
+        }
+
+        /// <summary>
+        /// Get position of header associated with item at position.
+        /// </summary>
+        /// <param name="position">Position of item to use to find header position.</param>
+        /// <returns>Position of header.</returns>
+        public int GetHeaderPosition(int position)
+        {
+            ITaskHeader heaader = GetHeaderAt(position);
+            return viewItemsSource.GetPosition(heaader);
+        }
+
+        /// <summary>
+        /// Check if item at positon is a header.
+        /// </summary>
+        /// <param name="position">Position of item.</param>
+        /// <returns><c>true</c> if item is header. Otherwise <c>false</c>.</returns>
+        public bool IsHeader(int position)
+        {
+            return viewItemsSource[position] is ITaskHeader;
         }
 
         /// <summary>
@@ -397,6 +479,34 @@ All changes must be synchronized on the main thread.");
         public int CountVisibleItemsInHeader(ITaskHeader header)
         {
             return header.IsCollapsed ? 0 : header.Items.Count;
+        }
+
+        /// <inheritdoc/>
+        public void OnHeaderClick(ITaskHeader header)
+        {
+            int position = viewItemsSource.GetPosition(header) + 1;
+
+            if (header.IsCollapsed)
+            {
+                var itemsToAdd = header.Items;
+                int pos = position;
+                foreach (var item in itemsToAdd)
+                {
+                    viewItemsSource.Insert(pos++, item);
+                }
+                header.IsCollapsed = false;
+                NotifyItemRangeInserted(position, itemsToAdd.Count);
+            }
+            else
+            {
+                var itemsToRemove = header.Items;
+                foreach (var item in itemsToRemove)
+                {
+                    viewItemsSource.Remove(item);
+                }
+                header.IsCollapsed = true;
+                NotifyItemRangeRemoved(position, itemsToRemove.Count);
+            }
         }
 
         /// <summary>
@@ -420,11 +530,11 @@ All changes must be synchronized on the main thread.");
 
             foreach (var group in groupedItems)
             {
-                var generatedHeader = GenerateHeader((THeader)group.Key);
+                ITaskHeader generatedHeader = GenerateHeader((THeader)group.Key);
 
                 if (group.Key == null)
                 {
-                    foreach (var item in group)
+                    foreach (ITaskItem item in group)
                     {
                         item.Header = generatedHeader.Header;
                     }
@@ -432,24 +542,26 @@ All changes must be synchronized on the main thread.");
 
                 if (taskItems.FirstOrDefault(item => item is ITaskHeader header && header.Header.Equals(generatedHeader.Header)) is ITaskHeader existingHeader)
                 {
-                    var headerItems = existingHeader.Items.ToList();
+                    List<ITaskItem> headerItems = existingHeader.Items.ToList();
                     existingHeader.Items.Clear();
                     taskItems.RemoveAll(item => headerItems.Contains(item));
                     headerItems.AddRange(group);
 
                     int position = taskItems.GetPosition(existingHeader) + 1;
 
-                    foreach (var item in headerItems.OrderByDescending(i => i.Sequence.HasValue).ThenBy(i => i.Sequence))
+                    foreach (ITaskItem item in headerItems.OrderByDescending(i => i.Sequence.HasValue).ThenBy(i => i.Sequence))
                     {
                         existingHeader.Items.Add(item);
                     }
 
                     if (!existingHeader.IsCollapsed)
+                    {
                         taskItems.InsertRange(position, existingHeader.Items);
+                    }
                 }
                 else
                 {
-                    foreach (var item in group.OrderByDescending(i => i.Sequence.HasValue).ThenBy(i => i.Sequence))
+                    foreach (ITaskItem item in group.OrderByDescending(i => i.Sequence.HasValue).ThenBy(i => i.Sequence))
                     {
                         generatedHeader.Items.Add(item);
                     }
@@ -457,7 +569,9 @@ All changes must be synchronized on the main thread.");
                     taskItems.Add(generatedHeader);
 
                     if (!generatedHeader.IsCollapsed)
+                    {
                         taskItems.AddRange(generatedHeader.Items);
+                    }
                 }
             }
 
@@ -466,7 +580,7 @@ All changes must be synchronized on the main thread.");
 
         /// <summary>
         /// Generate a header with a given model.
-        /// <para>This method can be overriden to fine-tune the grouping logic to add/edit/remove headers and/or specify header rules for specific headers.</para>
+        /// <para>This method can be overriden to fine-tune the grouping logic to add/edit/group headers and/or specify header rules.</para>
         /// <para>IMPORTANT: If header is nullable, make sure to handle nullable type by using a non-null value. E.g. Header type with <c>int?</c> will use <c>-1</c> when <c>null</c>.</para>
         /// </summary>
         /// <param name="model">Model used for generating header.</param>
@@ -474,9 +588,10 @@ All changes must be synchronized on the main thread.");
         protected virtual ITaskHeader GenerateHeader(THeader model)
         {
             if (model == null)
-                MvxAndroidLog.Instance.Log(LogLevel.Error,
-                    $@"The {nameof(model)} for header was null. Binding to ItemsSource will fail because grouping cannot be applied to null values.
+            {
+                MvxAndroidLog.Instance.Log(LogLevel.Error, $@"The {nameof(model)} for header was null. Binding to ItemsSource will fail because grouping cannot be applied to null values.
 If header is nullable, make sure to override {nameof(GenerateHeader)}() and handle nullable types by using a non-null value. E.g. Header type with int? will use -1 when null.");
+            }
 
             return new SimpleTaskHeader<THeader>(model?.ToString(), model);
         }
@@ -485,49 +600,31 @@ If header is nullable, make sure to override {nameof(GenerateHeader)}() and hand
         {
             if (sender is MvxRecyclerViewHolder holder && holder.DataContext is ITaskHeader header)
             {
-                int position = holder.AdapterPosition + 1;
-
-                if (header.IsCollapsed)
-                {
-                    var itemsToAdd = GetItemsInHeader(header);
-                    int pos = position;
-                    foreach (var item in itemsToAdd)
-                    {
-                        viewItemsSource.Insert(pos++, item);
-                    }
-                    header.IsCollapsed = false;
-                    NotifyItemRangeInserted(position, itemsToAdd.Count);
-                }
-                else
-                {
-                    var itemsToRemove = GetItemsInHeader(header);
-                    foreach (var item in itemsToRemove)
-                    {
-                        viewItemsSource.Remove(item);
-                    }
-                    header.IsCollapsed = true;
-                    NotifyItemRangeRemoved(position, itemsToRemove.Count);
-                }
+                OnHeaderClick(header);
             }
         }
 
         private void NotifyDataSetAdded(NotifyCollectionChangedEventArgs e)
         {
-            var newItems = e.NewItems.Cast<ITaskItem>().ToList();
-            foreach (var item in newItems)
+            IList<ITaskItem> newItems = e.NewItems.Cast<ITaskItem>().ToList();
+            foreach (ITaskItem item in newItems)
             {
-                var generatedHeader = GenerateHeader((THeader)item.Header);
+                ITaskHeader generatedHeader = GenerateHeader((THeader)item.Header);
 
-                var header = AddHeader(generatedHeader) ? generatedHeader : GetHeader(generatedHeader);
+                ITaskHeader header = AddHeader(generatedHeader) ? generatedHeader : GetHeader(generatedHeader);
 
                 int headerPosition = viewItemsSource.GetPosition(header);
 
                 if (header.IsCollapsed)
                 {
                     if (item.Sequence.HasValue && item.Sequence.Value <= header.Items.Count)
+                    {
                         header.Items.Insert(item.Sequence.Value, item);
+                    }
                     else
+                    {
                         header.Items.Add(item);
+                    }
                 }
                 else
                 {
@@ -543,8 +640,10 @@ If header is nullable, make sure to override {nameof(GenerateHeader)}() and hand
 
         private void NotifyDataSetMoved(NotifyCollectionChangedEventArgs e)
         {
-            for (var i = 0; i < e.NewItems.Count; i++)
+            for (int i = 0; i < e.NewItems.Count; i++)
+            {
                 NotifyItemMoved(GetViewPosition(e.OldStartingIndex + i), GetViewPosition(e.NewStartingIndex + i));
+            }
         }
 
         private void NotifyDataSetReplaced(NotifyCollectionChangedEventArgs e)
@@ -554,20 +653,16 @@ If header is nullable, make sure to override {nameof(GenerateHeader)}() and hand
 
         private void NotifyDataSetRemoved(NotifyCollectionChangedEventArgs e)
         {
-            var oldItems = e.OldItems.Cast<ITaskItem>().ToList();
-            foreach (var item in oldItems)
+            IList<ITaskItem> oldItems = e.OldItems.Cast<ITaskItem>().ToList();
+            foreach (ITaskItem item in oldItems)
             {
                 item.Sequence = null;
-                var header = GetHeader(item);
+                ITaskHeader header = GetHeader(item);
+                header.Items.Remove(item);
 
-                if (header.IsCollapsed)
+                if (!header.IsCollapsed)
                 {
-                    header.Items.Remove(item);
-                }
-                else
-                {
-                    var position = viewItemsSource.GetPosition(item);
-                    header.Items.Remove(item);
+                    int position = viewItemsSource.GetPosition(item);
                     viewItemsSource.Remove(item);
                     NotifyItemRemoved(GetViewPosition(position));
                 }
@@ -586,11 +681,13 @@ If header is nullable, make sure to override {nameof(GenerateHeader)}() and hand
         private void GenerateInitialHeaders()
         {
             if (viewItemsSource == null)
-                viewItemsSource = new List<ITaskItem>();
-
-            foreach (var initialHeader in AddInitialHeaders())
             {
-                var header = GenerateHeader(initialHeader);
+                viewItemsSource = new List<ITaskItem>();
+            }
+
+            foreach (THeader initialHeader in AddInitialHeaders())
+            {
+                ITaskHeader header = GenerateHeader(initialHeader);
                 AddHeader(header);
             }
         }
@@ -598,10 +695,12 @@ If header is nullable, make sure to override {nameof(GenerateHeader)}() and hand
         private bool AddHeader(ITaskHeader header)
         {
             if (viewItemsSource.Any(h => h.Header.Equals(header.Header)))
+            {
                 return false;
+            }
 
             viewItemsSource.Add(header);
-            var headers = GetHeaders();
+            IList<ITaskHeader> headers = GetHeaders();
 
             if (headers.Count <= 1)
             {
@@ -620,20 +719,21 @@ If header is nullable, make sure to override {nameof(GenerateHeader)}() and hand
             }
             else
             {
-                var aboveHeader = orderedHeaders.ElementAt(aboveHeaderPosition);
+                ITaskHeader aboveHeader = orderedHeaders.ElementAt(aboveHeaderPosition);
                 newHeaderPosition = viewItemsSource.GetPosition(aboveHeader) + CountVisibleItemsInHeader(aboveHeader) + 1;
             }
+
             viewItemsSource.Remove(header);
             viewItemsSource.Insert(newHeaderPosition, header);
             NotifyItemInserted(newHeaderPosition);
             return true;
         }
 
-        private bool TaskHeaderDragInDisabled(ITaskHeader newHeader, ITaskItem item)
+        private bool TaskHeaderDragInDisabled(ITaskHeader newHeader, ITaskItem item, RecyclerView recyclerView = null)
         {
             if (newHeader?.Rules.HasFlag(TaskHeaderRule.DragInDisabled) == true)
             {
-                var currentHeader = GetHeader(item);
+                ITaskHeader currentHeader = GetHeader(item);
                 int currentHeaderPosition = viewItemsSource.GetPosition(currentHeader);
                 bool positiveDirection = currentHeaderPosition < viewItemsSource.GetPosition(newHeader);
 
@@ -656,32 +756,72 @@ If header is nullable, make sure to override {nameof(GenerateHeader)}() and hand
                 int position = viewItemsSource.GetPosition(item);
                 viewItemsSource.Remove(item);
                 viewItemsSource.Insert(newPosition, item);
-                NotifyItemMoved(position, newPosition);
+                Notify(recyclerView, NotifyItemMoved, position, newPosition);
                 return true;
             }
+
             return false;
         }
 
-        private bool TaskHeaderDragOutDisabled(ITaskHeader header)
+        private bool RemoveTemporaryTaskHeader(ITaskItem item, RecyclerView recyclerView = null)
         {
-            return header?.Rules.HasFlag(TaskHeaderRule.DragOutDisabled) == true;
-        }
-
-        private bool RemoveTemporaryTaskHeader(ITaskItem item)
-        {
-            var itemHeader = GetHeader(item);
+            ITaskHeader itemHeader = GetHeader(item);
             if (itemHeader?.Rules.HasFlag(TaskHeaderRule.Temporary) == true)
             {
-                var items = GetItemsInHeader(itemHeader);
+                var items = itemHeader.Items;
                 if (items?.Count > 0)
+                {
                     return false;
+                }
 
                 int position = viewItemsSource.GetPosition(itemHeader);
                 viewItemsSource.Remove(itemHeader);
-                NotifyItemRemoved(position);
+                Notify(recyclerView, NotifyItemRemoved, position);
                 return true;
             }
+
             return false;
         }
+
+        #region Helper methods to prevent edge-case scenario where app sometimes crashes when dragging item above header and RecyclerView is scrolling. This happens in the "OnClearView" method where "NotifyItem****" methods are called before layout is computed.
+
+        /// <summary>
+        /// This helper method prevents crashes when dataset has been modified before the RecyclerView has finished computing its layout.
+        /// </summary>
+        /// <param name="recyclerView"><see cref="RecyclerView"/>.</param>
+        /// <param name="notify">Notify method.</param>
+        /// <param name="position">Position of ViewHolder.</param>
+        private void Notify(RecyclerView recyclerView, Action<int> notify, int position)
+        {
+            if (recyclerView?.IsComputingLayout == true)
+            {
+                recyclerView.Post(() => notify?.Invoke(position));
+            }
+            else
+            {
+                notify?.Invoke(position);
+            }
+        }
+
+        /// <summary>
+        /// This helper method prevents crashes when dataset range has been modified before the RecyclerView has finished computing its layout.
+        /// </summary>
+        /// <param name="recyclerView"><see cref="RecyclerView"/>.</param>
+        /// <param name="notifyRange">Notify range method.</param>
+        /// <param name="pos0">First parameter for given method.</param>
+        /// <param name="pos1">Second parameter for given method.</param>
+        private void Notify(RecyclerView recyclerView, Action<int, int> notifyRange, int pos0, int pos1)
+        {
+            if (recyclerView?.IsComputingLayout == true)
+            {
+                recyclerView.Post(() => notifyRange?.Invoke(pos0, pos1));
+            }
+            else
+            {
+                notifyRange?.Invoke(pos0, pos1);
+            }
+        }
+
+        #endregion
     }
 }

--- a/ExpandableRecyclerView.DroidX/MvxExpandableRecyclerBaseView.cs
+++ b/ExpandableRecyclerView.DroidX/MvxExpandableRecyclerBaseView.cs
@@ -1,0 +1,322 @@
+﻿using Android.Content;
+using Android.Runtime;
+using Android.Util;
+using AndroidX.RecyclerView.Widget;
+using MvvmCross.Binding.Attributes;
+using MvvmCross.DroidX.RecyclerView.AttributeHelpers;
+using MvvmCross.DroidX.RecyclerView.ItemTemplates;
+using MvvmCross.ExpandableRecyclerView.DroidX.Components;
+using MvvmCross.Platforms.Android.Binding.Views;
+using System;
+using System.Collections;
+using System.Windows.Input;
+
+namespace MvvmCross.ExpandableRecyclerView.DroidX
+{
+    /// <summary>
+    /// A bindable, expandable, draggable and swipe-able RecyclerView.
+    /// </summary>
+    public class MvxExpandableRecyclerBaseView : RecyclerView
+    {
+        private readonly StickyHeaderLayoutManager stickyHeaderLayoutManager;
+        private readonly ItemTouchHelperCallback itemTouchHelperCallback;
+
+        /// <summary>
+        /// Create an instance of MvxExpandableRecyclerBaseView.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        /// <param name="attrs">Attrs.</param>
+        public MvxExpandableRecyclerBaseView(Context context, IAttributeSet attrs)
+            : this(context, attrs, 0, new MvxExpandableRecyclerAdapter<object>())
+        { }
+
+        /// <summary>
+        /// Create an instance of MvxExpandableRecyclerBaseView.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        /// <param name="attrs">Attrs.</param>
+        /// <param name="defStyle">DefStyle.</param>
+        public MvxExpandableRecyclerBaseView(Context context, IAttributeSet attrs, int defStyle)
+            : this(context, attrs, defStyle, new MvxExpandableRecyclerAdapter<object>())
+        { }
+
+        /// <summary>
+        /// Create an instance of MvxExpandableRecyclerBaseView.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        /// <param name="attrs">Attrs.</param>
+        /// <param name="defStyle">DefStyle.</param>
+        /// <param name="adapter"><see cref="IMvxExpandableRecyclerAdapter"/> to use.</param>
+        public MvxExpandableRecyclerBaseView(Context context, IAttributeSet attrs, int defStyle, IMvxExpandableRecyclerAdapter adapter)
+            : base(context, attrs, defStyle)
+        {
+            if (adapter == null)
+            {
+                return;
+            }
+
+            LayoutManager currentLayoutManager = GetLayoutManager();
+            if (currentLayoutManager == null)
+            {
+                stickyHeaderLayoutManager = new StickyHeaderLayoutManager(context, adapter);
+                SetLayoutManager(stickyHeaderLayoutManager);
+            }
+
+            itemTouchHelperCallback = new ItemTouchHelperCallback(adapter);
+            ItemTouchHelper itemtouchhelper = new ItemTouchHelper(itemTouchHelperCallback);
+            itemtouchhelper.AttachToRecyclerView(this);
+
+            int itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
+            IMvxTemplateSelector itemTemplateSelector = MvxRecyclerViewAttributeExtensions.BuildItemTemplateSelector(context, attrs, itemTemplateId);
+
+            adapter.ItemTemplateSelector = itemTemplateSelector;
+            Adapter = adapter;
+
+            if (itemTemplateId == 0)
+            {
+                itemTemplateId = global::Android.Resource.Layout.SimpleListItem1;
+            }
+
+            if (itemTemplateSelector.GetType() == typeof(MvxDefaultTemplateSelector))
+            {
+                ItemTemplateId = itemTemplateId;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected MvxExpandableRecyclerBaseView(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        { }
+
+        /// <inheritdoc/>
+        protected override void OnDetachedFromWindow()
+        {
+            base.OnDetachedFromWindow();
+            DetachedFromWindow();
+        }
+
+        /// <inheritdoc/>
+        protected virtual void DetachedFromWindow()
+        {
+            GetLayoutManager()?.RemoveAllViews();
+        }
+
+        /// <summary>
+        /// Adapter.
+        /// </summary>
+        [MvxSetToNullAfterBinding]
+        public new IMvxExpandableRecyclerAdapter Adapter
+        {
+            get => GetAdapter() as IMvxExpandableRecyclerAdapter;
+            set
+            {
+                IMvxExpandableRecyclerAdapter existing = Adapter;
+                if (existing == value)
+                {
+                    return;
+                }
+
+                if (value != null && existing != null)
+                {
+                    value.ItemsSource = existing.ItemsSource;
+                    value.ItemTemplateSelector = existing.ItemTemplateSelector;
+                    value.ItemClick = existing.ItemClick;
+                    value.ItemLongClick = existing.ItemLongClick;
+                    value.ItemSwipeLeft = existing.ItemSwipeLeft;
+                    value.ItemSwipeRight = existing.ItemSwipeRight;
+                    value.EnableDrag = existing.EnableDrag;
+                    value.EnableSwipe = existing.EnableSwipe;
+
+                    SwapAdapter((Adapter)value, false);
+                }
+                else
+                {
+                    SetAdapter(value as Adapter);
+                }
+
+                stickyHeaderLayoutManager.Adapter = value;
+                itemTouchHelperCallback.Adapter = value;
+
+                if (existing != null)
+                {
+                    existing.ItemsSource = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get or set the ItemSource to use for the RecyclerView Adapter.
+        /// <para>
+        /// It is recommended to use a type inheriting from <see cref="IList"/>, such as
+        /// <see cref="System.Collections.ObjectModel.ObservableCollection{T}"/>,
+        /// <see cref="MvvmCross.ViewModels.MvxObservableCollection{T}"/> or
+        /// <see cref="System.Collections.Generic.List{T}"/>.
+        /// </para>
+        /// </summary>
+        [MvxSetToNullAfterBinding]
+        public IEnumerable ItemsSource
+        {
+            get => Adapter?.ItemsSource;
+            set
+            {
+                IMvxExpandableRecyclerAdapter adapter = Adapter;
+                if (adapter != null)
+                {
+                    adapter.ItemsSource = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get or set the Item Template Id for cases where you only have one type of view in the RecyclerView.
+        /// </summary>
+        public int ItemTemplateId
+        {
+            get
+            {
+                if (!(ItemTemplateSelector is MvxDefaultTemplateSelector singleItemDefaultTemplateSelector))
+                {
+                    throw new InvalidOperationException(
+                        "If you don't want to use single item-template RecyclerView Adapter you can't change it's" +
+                        $"{nameof(IMvxTemplateSelector)} to anything other than {nameof(MvxDefaultTemplateSelector)}");
+                }
+
+                return singleItemDefaultTemplateSelector.ItemTemplateId;
+            }
+            set
+            {
+                if (!(ItemTemplateSelector is MvxDefaultTemplateSelector singleItemDefaultTemplateSelector))
+                {
+                    throw new InvalidOperationException(
+                        "If you don't want to use single item-template RecyclerView Adapter you can't change it's" +
+                        $"{nameof(IMvxTemplateSelector)} to anything other than {nameof(MvxDefaultTemplateSelector)}");
+                }
+
+                singleItemDefaultTemplateSelector.ItemTemplateId = value;
+
+                if (Adapter != null)
+                {
+                    Adapter.ItemTemplateSelector = singleItemDefaultTemplateSelector;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get or set the ItemTemplateSelector.
+        /// </summary>
+        public IMvxTemplateSelector ItemTemplateSelector
+        {
+            get => Adapter?.ItemTemplateSelector;
+            set
+            {
+                if (Adapter != null)
+                {
+                    Adapter.ItemTemplateSelector = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get or set the <see cref="ICommand"/> to trigger when an item was clicked.
+        /// </summary>
+        [MvxSetToNullAfterBinding]
+        public ICommand ItemClick
+        {
+            get => Adapter?.ItemClick;
+            set
+            {
+                if (Adapter != null)
+                {
+                    Adapter.ItemClick = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get or set the <see cref="ICommand"/> to trigger when an item was long clicked.
+        /// </summary>
+        [MvxSetToNullAfterBinding]
+        public ICommand ItemLongClick
+        {
+            get => Adapter?.ItemLongClick;
+            set
+            {
+                if (Adapter != null)
+                {
+                    Adapter.ItemLongClick = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get or set the <see cref="ICommand"/> to trigger when an item was swiped towards the right.
+        /// </summary>
+        [MvxSetToNullAfterBinding]
+        public ICommand ItemSwipeRight
+        {
+            get => Adapter?.ItemSwipeRight;
+            set
+            {
+                if (Adapter != null)
+                {
+                    Adapter.ItemSwipeRight = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get or set the <see cref="ICommand"/> to trigger when an item was swiped towards the left.
+        /// </summary>
+        [MvxSetToNullAfterBinding]
+        public ICommand ItemSwipeLeft
+        {
+            get => Adapter?.ItemSwipeLeft;
+            set
+            {
+                if (Adapter != null)
+                {
+                    Adapter.ItemSwipeLeft = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Whether to show or hide sticky header.
+        /// </summary>
+        public bool ShowStickyHeader
+        {
+            get => stickyHeaderLayoutManager.ShowStickyHeader;
+            set => stickyHeaderLayoutManager.ShowStickyHeader = value;
+        }
+
+        /// <summary>
+        /// Whether to enable RecyclerView dragging.
+        /// </summary>
+        public bool EnableDrag
+        {
+            get => Adapter?.EnableDrag ?? false;
+            set
+            {
+                if (Adapter != null)
+                {
+                    Adapter.EnableDrag = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Whether to enable RecyclerView swiping.
+        /// </summary>
+        public bool EnableSwipe
+        {
+            get => Adapter?.EnableSwipe ?? false;
+            set
+            {
+                if (Adapter != null)
+                {
+                    Adapter.EnableSwipe = value;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented sticky header to constantly show a header at the top of the screen and dynamically change depending on the top-most item being displayed. You can hide the sticky header by binding `false` to the property `ShowStickyHeader`. Also implemented binding properties `EnableDrag` and `EnableSwipe` to enable/disable dragging and swiping, respectively. 