### PR TITLE
Improve loading speed. Fix swipe bug. Fix resizing sticky header bug

### DIFF
--- a/ExpandableRecyclerView.Core/ExpandableRecyclerView.Core.csproj
+++ b/ExpandableRecyclerView.Core/ExpandableRecyclerView.Core.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>MvvmCross.ExpandableRecyclerView.Core</AssemblyName>
 		<PackageId>MvxExpandableRecyclerView.Core</PackageId>
 		<RootNamespace>MvvmCross.ExpandableRecyclerView.Core</RootNamespace>
-		<Version>3.0.0</Version>
+		<Version>3.0.1</Version>
 		<Authors>Mohammed Ali Ahmed</Authors>
 		<Company>Mohammed Ali Ahmed</Company>
 		<Product>MvxExpandableRecyclerView</Product>

--- a/ExpandableRecyclerView.DroidX/Components/ItemTouchHelperCallback.cs
+++ b/ExpandableRecyclerView.DroidX/Components/ItemTouchHelperCallback.cs
@@ -43,19 +43,19 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX.Components
                 return ItemTouchHelper.ActionStateIdle;
             }
 
-            var holder = (IMvxRecyclerViewHolder)p1;
+            IMvxRecyclerViewHolder holder = (IMvxRecyclerViewHolder)p1;
             if (holder.DataContext is ITaskHeader)
             {
                 return ItemTouchHelper.ActionStateIdle;
             }
 
-            var item = (ITaskItem)holder.DataContext;
+            ITaskItem item = (ITaskItem)holder.DataContext;
             if (item == null)
             {
                 return ItemTouchHelper.ActionStateIdle;
             }
 
-            var header = adapter.GetHeader(item);
+            ITaskHeader header = adapter.GetHeader(item);
             if (header == null)
             {
                 return ItemTouchHelper.ActionStateIdle;
@@ -111,15 +111,15 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX.Components
             }
             else if (rules.HasFlag(TaskHeaderRule.SwipeLeftDisabled))
             {
-                return ItemTouchHelper.End;
+                return ItemTouchHelper.Right;
             }
             else if (rules.HasFlag(TaskHeaderRule.SwipeRightDisabled))
             {
-                return ItemTouchHelper.Start;
+                return ItemTouchHelper.Left;
             }
             else
             {
-                return ItemTouchHelper.Start | ItemTouchHelper.End;
+                return ItemTouchHelper.Left | ItemTouchHelper.Right;
             }
         }
     }

--- a/ExpandableRecyclerView.DroidX/ExpandableRecyclerView.DroidX.csproj
+++ b/ExpandableRecyclerView.DroidX/ExpandableRecyclerView.DroidX.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>MvvmCross.ExpandableRecyclerView.DroidX</AssemblyName>
 		<PackageId>MvxExpandableRecyclerView.DroidX</PackageId>
 		<RootNamespace>MvvmCross.ExpandableRecyclerView.DroidX</RootNamespace>
-		<Version>3.0.0</Version>
+		<Version>3.0.1</Version>
 		<Authors>Mohammed Ali Ahmed</Authors>
 		<Company>Mohammed Ali Ahmed</Company>
 		<Product>MvxExpandableRecyclerView</Product>

--- a/ExpandableRecyclerView.DroidX/Models/ITaskHeader.cs
+++ b/ExpandableRecyclerView.DroidX/Models/ITaskHeader.cs
@@ -1,5 +1,5 @@
 ﻿using MvvmCross.ExpandableRecyclerView.Core;
-using System.Collections.ObjectModel;
+using MvvmCross.ViewModels;
 
 namespace MvvmCross.ExpandableRecyclerView.DroidX
 {
@@ -21,7 +21,7 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         /// <summary>
         /// The items under this header.
         /// </summary>
-        ObservableCollection<ITaskItem> Items { get; set; }
+        MvxObservableCollection<ITaskItem> Items { get; set; }
 
         /// <summary>
         /// The number of items under this header.

--- a/ExpandableRecyclerView.DroidX/Models/TaskHeader.cs
+++ b/ExpandableRecyclerView.DroidX/Models/TaskHeader.cs
@@ -1,7 +1,7 @@
 ﻿using MvvmCross.Binding.Extensions;
 using MvvmCross.ExpandableRecyclerView.Core;
+using MvvmCross.ViewModels;
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 
@@ -15,7 +15,7 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
     public abstract class TaskHeader<TModel, THeader> : TaskItem<TModel, THeader>, ITaskHeader
     {
         private bool isCollapsed;
-        private ObservableCollection<ITaskItem> items;
+        private MvxObservableCollection<ITaskItem> items;
         private bool isSticky;
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
             : base(model)
         {
             Name = name;
-            Items = new ObservableCollection<ITaskItem>();
+            Items = new MvxObservableCollection<ITaskItem>();
             Items.CollectionChanged += Items_CollectionChanged;
         }
 
@@ -39,7 +39,7 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
         public bool IsCollapsed { get => isCollapsed; set => SetProperty(ref isCollapsed, value); }
 
         /// <inheritdoc/>
-        public ObservableCollection<ITaskItem> Items
+        public MvxObservableCollection<ITaskItem> Items
         {
             get => items;
             set

--- a/ExpandableRecyclerView.DroidX/MvxExpandableRecyclerBaseView.cs
+++ b/ExpandableRecyclerView.DroidX/MvxExpandableRecyclerBaseView.cs
@@ -58,7 +58,7 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
             LayoutManager currentLayoutManager = GetLayoutManager();
             if (currentLayoutManager == null)
             {
-                stickyHeaderLayoutManager = new StickyHeaderLayoutManager(context, adapter);
+                stickyHeaderLayoutManager = new StickyHeaderLayoutManager(context, attrs, adapter);
                 SetLayoutManager(stickyHeaderLayoutManager);
             }
 


### PR DESCRIPTION
This PR improves the control's loading speed when initialised. Also fixes the swipe feature that was broken previously. The sticky header now accounts for animating different sized headers when changing sticky headers.