### PR TITLE
Fix crash when device is rotated

### DIFF
--- a/ExpandableRecyclerView.Core/ExpandableRecyclerView.Core.csproj
+++ b/ExpandableRecyclerView.Core/ExpandableRecyclerView.Core.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>MvvmCross.ExpandableRecyclerView.Core</AssemblyName>
 		<PackageId>MvxExpandableRecyclerView.Core</PackageId>
 		<RootNamespace>MvvmCross.ExpandableRecyclerView.Core</RootNamespace>
-		<Version>3.0.1</Version>
+		<Version>3.0.2</Version>
 		<Authors>Mohammed Ali Ahmed</Authors>
 		<Company>Mohammed Ali Ahmed</Company>
 		<Product>MvxExpandableRecyclerView</Product>

--- a/ExpandableRecyclerView.DroidX/Components/ParcelableCreator.cs
+++ b/ExpandableRecyclerView.DroidX/Components/ParcelableCreator.cs
@@ -1,0 +1,31 @@
+﻿using Android.OS;
+using System;
+
+namespace MvvmCross.ExpandableRecyclerView.DroidX.Components
+{
+    internal class ParcelableCreator<T> : Java.Lang.Object, IParcelableCreator where T : Java.Lang.Object, new()
+    {
+        /// <summary>
+        /// Function for the creation of a parcel.
+        /// </summary>
+        private readonly Func<Parcel, T> createFunc;
+
+        /// <summary>
+        /// Initialize an instance of the GenericParcelableCreator.
+        /// </summary>
+        public ParcelableCreator(Func<Parcel, T> createFromParcelFunc)
+        {
+            createFunc = createFromParcelFunc;
+        }
+
+        /// <summary>
+        /// Create a parcelable from a parcel.
+        /// </summary>
+        public Java.Lang.Object CreateFromParcel(Parcel parcel) => createFunc(parcel);
+
+        /// <summary>
+        /// Create an array from the parcelable class.
+        /// </summary>
+        public Java.Lang.Object[] NewArray(int size) => new T[size];
+    }
+}

--- a/ExpandableRecyclerView.DroidX/ExpandableRecyclerView.DroidX.csproj
+++ b/ExpandableRecyclerView.DroidX/ExpandableRecyclerView.DroidX.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>MvvmCross.ExpandableRecyclerView.DroidX</AssemblyName>
 		<PackageId>MvxExpandableRecyclerView.DroidX</PackageId>
 		<RootNamespace>MvvmCross.ExpandableRecyclerView.DroidX</RootNamespace>
-		<Version>3.0.1</Version>
+		<Version>3.0.2</Version>
 		<Authors>Mohammed Ali Ahmed</Authors>
 		<Company>Mohammed Ali Ahmed</Company>
 		<Product>MvxExpandableRecyclerView</Product>
@@ -22,6 +22,10 @@ This is an unofficial package that contains an expandable AndroidX RecyclerView 
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
+
+	<ItemGroup>
+	  <AndroidResource Include="Resources\values\ExpandableRecyclerViewIds.xml" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />

--- a/ExpandableRecyclerView.DroidX/MvxExpandableRecyclerView.cs
+++ b/ExpandableRecyclerView.DroidX/MvxExpandableRecyclerView.cs
@@ -1,10 +1,8 @@
 ﻿using Android.Content;
-using Android.OS;
 using Android.Runtime;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
-using AndroidX.Core.View;
 using AndroidX.RecyclerView.Widget;
 using MvvmCross.Binding.Attributes;
 using MvvmCross.DroidX.RecyclerView.ItemTemplates;
@@ -219,31 +217,11 @@ namespace MvvmCross.ExpandableRecyclerView.DroidX
             set => expandableRecyclerBaseView.EnableSwipe = value;
         }
 
-        /// <inheritdoc/>
-        protected override IParcelable OnSaveInstanceState()
-        {
-            Bundle bundle = new Bundle();
-            bundle.PutInt("viewId", expandableRecyclerBaseView.Id);
-            bundle.PutParcelable("superState", base.OnSaveInstanceState());
-            return bundle;
-        }
-
-        /// <inheritdoc/>
-        protected override void OnRestoreInstanceState(IParcelable state)
-        {
-            Bundle bundle = (Bundle)state;
-            expandableRecyclerBaseView.Id = bundle.GetInt("viewId");
-            IParcelable superState = (IParcelable)bundle.GetParcelable("superState");
-            base.OnRestoreInstanceState(superState);
-        }
-
         private void InitialiseRecyclerView()
         {
-            expandableRecyclerBaseView.HasFixedSize = true;
-
             if (expandableRecyclerBaseView.Id == Id)
             {
-                expandableRecyclerBaseView.Id = ViewCompat.GenerateViewId();
+                expandableRecyclerBaseView.Id = Resource.Id.mvx_expandable_recycler_base_view;
             }
 
             AddView(expandableRecyclerBaseView, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent));

--- a/ExpandableRecyclerView.DroidX/Resources/values/ExpandableRecyclerViewIds.xml
+++ b/ExpandableRecyclerView.DroidX/Resources/values/ExpandableRecyclerViewIds.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+  <item type="id" name="mvx_expandable_recycler_base_view"/>
+</resources>


### PR DESCRIPTION
This PR fixes the issue where the app would crash when the device is rotated. This was due to `MvxExpandableRecyclerParcel` not being setup correctly initially.